### PR TITLE
Add conditions for pushing images from GithubCI to DockerHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        if: github.event_name == 'push'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -28,5 +29,5 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'push' }}
           tags: sysprog21/chisel-bootcamp:latest


### PR DESCRIPTION
The PR restricts the condition for GithubCI to push the docker image to DockerHub, so the pull requests will perform the GithubCI build runs but it won't pollute the DockerHub images by pushing the built images up there.