### PR TITLE
Fix dotvisualizer import error

### DIFF
--- a/2.1_first_module.ipynb
+++ b/2.1_first_module.ipynb
@@ -51,13 +51,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import chisel3._\n",
-    "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test\n",
-    "import dotvisualizer._"
-   ]
+   "source": "import chisel3._\nimport chisel3.util._\nimport chisel3.tester._\nimport chisel3.tester.RawTester.test"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
firrtl-diagrammer library was removed from load-ivy.sc due to json4s compatibility issues with Chisel 3.6. Thus, we shall remove obsolete dotvisualizer import from cell-5.

Alternative visualization functions (visualize, visualizeHierarchy) are implemented directly in source/load-ivy.sc and work without this import.

Closes #12