### PR TITLE
Fix chiseltest import path for 0.6.x namespace

### DIFF
--- a/2.1_first_module.ipynb
+++ b/2.1_first_module.ipynb
@@ -51,7 +51,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import chisel3._\nimport chisel3.util._\nimport chisel3.tester._\nimport chisel3.tester.RawTester.test"
+   "source": "import chisel3._\nimport chisel3.util._\nimport chiseltest._\nimport chiseltest.RawTester.test"
   },
   {
    "cell_type": "markdown",

--- a/2.2_comb_logic.ipynb
+++ b/2.2_comb_logic.ipynb
@@ -45,8 +45,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {

--- a/2.3_control_flow.ipynb
+++ b/2.3_control_flow.ipynb
@@ -46,8 +46,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {

--- a/2.4_sequential_logic.ipynb
+++ b/2.4_sequential_logic.ipynb
@@ -45,8 +45,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {

--- a/2.5_exercise.ipynb
+++ b/2.5_exercise.ipynb
@@ -39,8 +39,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {

--- a/2.6_chiseltest.ipynb
+++ b/2.6_chiseltest.ipynb
@@ -50,8 +50,8 @@
     "import chisel3.util._\n",
     "import chisel3.experimental._\n",
     "import chisel3.experimental.BundleLiterals._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "source": [
     ">This bootcamp requires some slight differences from the imports you might see \n",
-    "elsewhere for chisel. The `import chisel3.tester.RawTester.test` brings in \n",
+    "elsewhere for chisel. The `import chiseltest.RawTester.test` brings in \n",
     "version of `test(...)` below that is designed specifically for the bootcamp"
    ]
   },
@@ -194,15 +194,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Modules with Decoupled Interfaces\n",
-    "In this section we will look at some of the tester2's tools for working with `Decoupled` interfaces.\n",
-    "`Decoupled` takes a chisel data type and provides it with `ready` and `valid` signals.\n",
-    "ChiselTest provides some nice tools for automating and reliably testing these interfaces.\n",
-    "\n",
-    "## A queue example\n",
-    "The `QueueModule` passes through data whose type is determined by `ioType`. There are `entries` state elements inside the `QueueModule` meaning it can hold that many elements before it exerts backpressure."
-   ]
+   "source": "# Modules with Decoupled Interfaces\nIn this section we will look at some of ChiselTest's tools for working with `Decoupled` interfaces.\n`Decoupled` takes a chisel data type and provides it with `ready` and `valid` signals.\nChiselTest provides some nice tools for automating and reliably testing these interfaces.\n\n## A queue example\nThe `QueueModule` passes through data whose type is determined by `ioType`. There are `entries` state elements inside the `QueueModule` meaning it can hold that many elements before it exerts backpressure."
   },
   {
    "cell_type": "code",
@@ -295,11 +287,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "> One more important take away from the last section is that the functions we just saw, `enqueueNow`, \n",
-    "`enqueueSeq`, `expectDequeueNow`, and `expectDequeueSeq` are not complicated special case logic in ChiselTest.\n",
-    "Rather they are examples of the kinds of harness building that ChiselTest encourages you to build from the ChiselTest primitives. To see how these methods are implemented check out [TestAdapters.scala](https://github.com/ucb-bar/chisel-testers2/blob/d199c5908828d0be5245f55fce8a872b2afb314e/src/main/scala/chisel3/tester/TestAdapters.scala)"
-   ]
+   "source": "> One more important take away from the last section is that the functions we just saw, `enqueueNow`, \n`enqueueSeq`, `expectDequeueNow`, and `expectDequeueSeq` are not complicated special case logic in ChiselTest.\nRather they are examples of the kinds of harness building that ChiselTest encourages you to build from the ChiselTest primitives. To see how these methods are implemented check out [TestAdapters.scala](https://github.com/ucb-bar/chiseltest/blob/main/src/main/scala/chiseltest/TestAdapters.scala)"
   },
   {
    "cell_type": "markdown",
@@ -311,19 +299,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "In this section we will look at running sections of a unit test concurrently. In order to do this we will introduce two new features of testers2.\n",
-    "\n",
-    "| method | description |\n",
-    "| :---   | :---        |\n",
-    "| fork   | launches a concurrent code block, additional forks can be run concurrently to this one via the .fork appended to end of the code block of the preceeding fork |\n",
-    "| join | re-unites multiple related forks back into the calling thread |\n",
-    "---\n",
-    "\n",
-    "In the example below two `fork`s are chained together, and then `join`ed. In the first `fork` block the `enqueueSeq` will continue to add elements until exhausted. The second `fork` block will `expectDequeueSeq` on each cycle when data is available.\n",
-    "\n",
-    ">The threads created by fork are run in a deterministic order, largely according to their order as specified in code, and certain bug-prone operations that depend on other threads are forbidden with runtime checks. \n"
-   ]
+   "source": "In this section we will look at running sections of a unit test concurrently. In order to do this we will introduce two new features of ChiselTest.\n\n| method | description |\n| :---   | :---        |\n| fork   | launches a concurrent code block, additional forks can be run concurrently to this one via the .fork appended to end of the code block of the preceeding fork |\n| join | re-unites multiple related forks back into the calling thread |\n---\n\nIn the example below two `fork`s are chained together, and then `join`ed. In the first `fork` block the `enqueueSeq` will continue to add elements until exhausted. The second `fork` block will `expectDequeueSeq` on each cycle when data is available.\n\n>The threads created by fork are run in a deterministic order, largely according to their order as specified in code, and certain bug-prone operations that depend on other threads are forbidden with runtime checks. "
   },
   {
    "cell_type": "code",

--- a/3.1_parameters.ipynb
+++ b/3.1_parameters.ipynb
@@ -43,8 +43,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {

--- a/3.2_collections.ipynb
+++ b/3.2_collections.ipynb
@@ -49,8 +49,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test\n",
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test\n",
     "import scala.collection._"
    ]
   },

--- a/3.2_interlude.ipynb
+++ b/3.2_interlude.ipynb
@@ -39,8 +39,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {

--- a/3.3_higher-order_functions.ipynb
+++ b/3.3_higher-order_functions.ipynb
@@ -39,8 +39,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {

--- a/3.4_functional_programming.ipynb
+++ b/3.4_functional_programming.ipynb
@@ -46,8 +46,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test\n",
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test\n",
     "import chisel3.experimental._\n",
     "import chisel3.internal.firrtl.KnownBinaryPoint"
    ]

--- a/3.5_object_oriented_programming.ipynb
+++ b/3.5_object_oriented_programming.ipynb
@@ -43,8 +43,8 @@
     "import chisel3._\n",
     "import chisel3.util._\n",
     "import chisel3.experimental._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {

--- a/3.6_types.ipynb
+++ b/3.6_types.ipynb
@@ -47,8 +47,8 @@
    "source": [
     "import chisel3._\n",
     "import chisel3.util._\n",
-    "import chisel3.tester._\n",
-    "import chisel3.tester.RawTester.test"
+    "import chiseltest._\n",
+    "import chiseltest.RawTester.test"
    ]
   },
   {


### PR DESCRIPTION
Problem: notebooks used 'import chisel3.tester._' which no longer exists in chiseltest 0.6.x, causing "object tester is not a member of package chisel3" compilation errors.

Root cause: chiseltest 0.6.x moved from `chisel3.tester` package to the top-level 'chiseltest' package namespace.

Fix: Update imports to 'chiseltest._' and 'chiseltest.RawTester.test' across all notebooks. Update stale prose references to chisel-testers2 in 2.6_chiseltest.ipynb.

Reported-by: JimmyCh1025

Close #15